### PR TITLE
Fix Update Failure

### DIFF
--- a/src/com/github/florent37/Generator.java
+++ b/src/com/github/florent37/Generator.java
@@ -30,7 +30,7 @@ public class Generator extends AnAction {
         //only display on .dart files
         final Project project = e.getProject();
         if (project != null) {
-            final Editor editor = e.getRequiredData(CommonDataKeys.EDITOR);
+            final Editor editor = e.getData(CommonDataKeys.EDITOR);
             final PsiFile file = PsiUtilBase.getPsiFileInEditor(editor, project);
             if (file != null) {
                 String fileName = file.getName();


### PR DESCRIPTION
Fixes assertion error during plugin updates, see below.

```java
update failed for AnAction(com.github.florent37.Generator) with ID=florent37.JsonSerializable.Generator

java.lang.AssertionError
	at com.intellij.openapi.actionSystem.AnActionEvent.getRequiredData(AnActionEvent.ja///va:221)
	at com.github.florent37.Generator.update(Generator.java:33)
        {...}
```